### PR TITLE
test link for Biosubsets

### DIFF
--- a/src/components/layouts/Layout.js
+++ b/src/components/layouts/Layout.js
@@ -63,8 +63,12 @@ function Side({ onClick }) {
       </Link>
       <ul className="Layout__side__items">
         <MenuInternalLinkItem
-          href="/publications?&amp;filters=genomes:>0"
+          href="/publications?filters=genomes:>0"
           label="Publications"
+        />
+        <MenuInternalLinkItem
+          href="/biosubsets?filters=NCIT"
+          label="Biosubsets"
         />
         <li>
           <MenuLink href="https://info.progenetix.org/">Info </MenuLink>

--- a/src/components/layouts/Layout.js
+++ b/src/components/layouts/Layout.js
@@ -70,6 +70,15 @@ function Side({ onClick }) {
           href="/biosubsets?filters=NCIT"
           label="Biosubsets"
         />
+        <ul>
+          <MenuInternalLinkItem href="/biosubsets?filters=NCIT" label="NCIT" isSub />
+        </ul>
+        <ul>
+          <MenuInternalLinkItem href="/biosubsets?filters=icdom" label="ICD-O Histo" isSub />
+        </ul>
+        <ul>
+          <MenuInternalLinkItem href="/biosubsets?filters=icdot" label="ICD-O Topo" isSub />
+        </ul>
         <li>
           <MenuLink href="https://info.progenetix.org/">Info </MenuLink>
         </li>

--- a/src/modules/biosubsets/BioSubsetsPage.js
+++ b/src/modules/biosubsets/BioSubsetsPage.js
@@ -86,7 +86,7 @@ function SubsetsTree({ tree }) {
     const override = state.collapsedOverrides[path.join(".")]
     if (override != null) return override
     const defaultCollapsed = state.defaultCollapsed
-    const depth = path.length - 1 // 2 because 1 is the tree fake "root"
+    const depth = path.length - 2 // 2 because 1 is the tree fake "root"
     if (!defaultCollapsed) return depth > state.defaultExpandedLevel
     return defaultCollapsed
   }
@@ -171,6 +171,8 @@ function SubsetNode({ node, dispatch, groupExpanded, depth }) {
   const { name, subset, children } = node
   const key = node.path.join(".")
   const marginLeft = `${depth}rem`
+  // TODO: dataset link is just for testing; should lead to details page
+  const dataset = "progenetix"
   return (
     <tr>
       <td style={{ width: 20 }}>
@@ -191,7 +193,7 @@ function SubsetNode({ node, dispatch, groupExpanded, depth }) {
           </span>
         </span>
       </td>
-      <td style={{ width: 20 }}>{subset?.count}</td>
+      <td style={{ width: 25 }}>{subset?.count} <a href={`https://progenetix.org/cgi/pgx_subsets.cgi?filters=${name}&datasetIds=${dataset}`}>{"{↗}"}</a></td>
     </tr>
   )
 }


### PR DESCRIPTION
This adds a link to the current biosubsets page (main progenetix.org; should actually be progenetix.TLD). For testing/demo, until details page has been implemented.