### PR TITLE
Fix 404 from group site link

### DIFF
--- a/src/site-specific/config.js
+++ b/src/site-specific/config.js
@@ -6,5 +6,5 @@ module.exports = {
     "data_master_site": "https://progenetix.org",
     "docs_master_site": "https://docs.progenetix.org",
     "news_site": "https://docs.progenetix.org/news",
-    "organization_site": "https://info.baudisgroup.org"
+    "organization_site": "https://baudisgroup.org"
 }


### PR DESCRIPTION
Spotted that the "Baudisgroup @ UZH" link seems broken